### PR TITLE
Add unit test, fix wildcard bug

### DIFF
--- a/Slots.Tests/SlotTests.cs
+++ b/Slots.Tests/SlotTests.cs
@@ -55,6 +55,18 @@ public class SlotTests
 		losingRow.Cells[1].Symbol = TestUtil.Symbols[0];
 		losingRow.Cells[2].Symbol = TestUtil.Symbols[1];
 		Assert.False(losingRow.IsWinningRow());
+
+		// Checking when wildcard (*) comes first in a winning row
+		var wildcardRow = new Row(3);
+		wildcardRow.Cells[0].Symbol = TestUtil.Symbols[3];
+		wildcardRow.Cells[1].Symbol = TestUtil.Symbols[0];
+		wildcardRow.Cells[2].Symbol = TestUtil.Symbols[0];
+		Assert.True(wildcardRow.IsWinningRow());
+
+		wildcardRow.Cells[0].Symbol = TestUtil.Symbols[3];
+		wildcardRow.Cells[1].Symbol = TestUtil.Symbols[3];
+		wildcardRow.Cells[2].Symbol = TestUtil.Symbols[3];
+		Assert.True(wildcardRow.IsWinningRow());
 	}
 
 	[Fact]

--- a/Slots/Row.cs
+++ b/Slots/Row.cs
@@ -14,9 +14,15 @@ public class Row(int length = 3)
 
 	public bool IsWinningRow()
 	{
-		string firstSymbol = Cells[0].Symbol.DisplayText;
+		string? firstSymbol = Cells.FirstOrDefault(cell => cell.Symbol.DisplayText != "*")?.Symbol.DisplayText;
+		
+		if (firstSymbol == null)
+		{
+			return true;
+		}
+
 		return Cells.All(cell => cell.Symbol.DisplayText == "*" || cell.Symbol.DisplayText == firstSymbol);
-	} 
+	}
 	
 	public override string ToString() => string.Join("", Cells.Select(cell => cell.ToString()));
 }


### PR DESCRIPTION
Resolved issue where a wildcard (*) appearing first in a 'winning' row would incorrectly count as a loss.
Added unit tests to validate.